### PR TITLE
statisk path for css

### DIFF
--- a/ukmidebank.php
+++ b/ukmidebank.php
@@ -57,7 +57,7 @@ function UKMide_menu() {
 function UKMide_scripts_and_styles(){
 	wp_enqueue_script('WPbootstrap3_js');
 	wp_enqueue_style('WPbootstrap3_css');
-	wp_enqueue_style( 'UKMide_css', plugin_dir_url( __FILE__ ) .'ukmidebank.css');
+	wp_enqueue_style( 'UKMide_css', PLUGIN_PATH .'UKMidebank/ukmidebank.css');
 }
 
 function UKMide() {


### PR DESCRIPTION
Bruker en final variable for å definere statisk path-en for å peke på resurser.

Deriverer fra: https://github.com/UKMNorge/UKMresources/issues/3

OBS: UKMconfig.inc.php er modifisert. Denne linjen er lagt til:
"# RESOURCES PLUGIN PATH
define('PLUGIN_PATH', 'https://' . UKM_HOSTNAME . '/wp-content/plugins/');"